### PR TITLE
updated installation to correct npm package

### DIFF
--- a/doc/GoogleSheetsConnector.md
+++ b/doc/GoogleSheetsConnector.md
@@ -1,6 +1,6 @@
 ## Reshuffle Google Sheets Connector
 
-`npm install reshuffle-google-sheets-connector`
+`npm install reshuffle-google-connectors`
 
 
 This is a [Reshuffle](https://dev.reshuffle.com) connector that allows you to Interact with online Google Sheets.


### PR DESCRIPTION
Small update to the npm installation. The original "npm install reshuffle-google-sheets-connector" does not exist in the npm registry